### PR TITLE
Fix: Remove unreliable list/verification feature/step

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -99,7 +99,6 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ github.token }}"
           charts_path: "${{ needs.build.outputs.charts_build_dir }}"
-          show_charts: 'true'
 
   dockerhub-publish:
     name: 'Publish [DockerHub]'
@@ -132,5 +131,4 @@ jobs:
           username: "${{ vars.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
           charts_path: "${{ needs.build.outputs.charts_build_dir }}"
-          show_charts: 'true'
           organisation: 'oransc'

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ environment setup tasks before invoking the action; below is an example:
 | organisation | False    | `${{ github.repository_owner }}` | Organization/namespace in the container registry        |
 | charts_path  | False    | `./chartstorage`                 | Path to the Helm charts directory                       |
 | permit_fail  | False    | `false`                          | Allow action to fail without failing the workflow       |
-| show_charts  | False    | `false`                          | Show/list published Helm charts in registry after push  |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -92,8 +91,6 @@ This action performs the following steps:
    provided credentials
 3. **Publishing**: Packages and pushes Helm chart files (.tgz) from the
    specified charts directory to the OCI registry
-4. **Optional Listing**: When `show_charts` enabled, lists published charts
-   in the registry after a propagation delay
 
 The action searches for `.tgz` files in the specified charts directory and
 publishes each chart to the registry using the format:

--- a/action.yaml
+++ b/action.yaml
@@ -36,13 +36,6 @@ inputs:
     # This is a boolean input, but GitHub Actions does not support
     # boolean types directly. We treat it as a string and handle it
     # in the action logic
-  show_charts:
-    description: 'Show/list published Helm charts in registry after publishing'
-    required: false
-    default: 'false'
-    # This is a boolean input, but GitHub Actions does not support
-    # boolean types directly. We treat it as a string and handle it
-    # in the action logic
 
 outputs:
   published_files:
@@ -269,49 +262,4 @@ runs:
         else
           echo "### All content published successfully 🎉" \
             >> "$GITHUB_STEP_SUMMARY"
-        fi
-
-    - name: 'Show/list Helm Charts in Registry [Optional]'
-      if: ${{ inputs.show_charts == 'true' }}
-      shell: bash
-      run: |
-        # Show/list Helm Charts in Registry
-
-        # Wait for registry to propagate changes
-        echo 'Waiting for registry to propagate changes... ⏳'
-        sleep 60
-
-        echo "Listing published Helm Charts in registry: ${{ inputs.registry }} 📋"
-
-        # Get the list of successfully published charts from previous step
-        if [ -n "${{ steps.publish.outputs.published_files }}" ]; then
-          # Parse comma-separated list of published files
-          IFS=',' read -ra PUBLISHED_ARRAY <<< "${{ steps.publish.outputs.published_files }}"
-          for filename in "${PUBLISHED_ARRAY[@]}"; do
-            if [ -n "$filename" ]; then
-              # Find the full path to extract chart name
-              full_path=$(find "${{ inputs.charts_path }}" -name "$filename" -type f | head -n1)
-              if [ -n "$full_path" ]; then
-                chart_repo=$(helm show chart "$full_path" 2>/dev/null | \
-                  awk -F': ' '/^name:/ {print $2}' | head -n1)
-                if [ -n "$chart_repo" ]; then
-                  echo "📦 Checking chart: $chart_repo"
-                  # Try to show the chart information from the registry
-                  set +e  # Don't exit on error for individual chart queries
-                  if helm show chart \
-                    "oci://${{ inputs.registry }}/${{ inputs.organisation }}/${chart_repo}" \
-                    2>/dev/null; then
-                    echo "✅ Chart $chart_repo is available in registry"
-                  else
-                    echo "⚠️  Could not retrieve chart $chart_repo from registry" \
-                      '(may take time to propagate)'
-                  fi
-                  set -e
-                  echo '---'
-                fi
-              fi
-            fi
-          done
-        else
-          echo 'No charts were successfully published ⚠️'
         fi


### PR DESCRIPTION
OCI container registries take time to process uploaded files. This is a feature of multiple registries, and due to their nature, interaction with CDNs, and mirroring, propagation delays mean that verification of uploads cannot take place in a reasonable time limit from inside CI/CD pipelines. It is therefore best to remove the feature, rather than try to build complex changes into the action.