### PR TITLE
CI(testing): Use DockerHub username as organisation

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -131,4 +131,4 @@ jobs:
           username: "${{ vars.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
           charts_path: "${{ needs.build.outputs.charts_build_dir }}"
-          organisation: 'oransc'
+          organisation: "${{ vars.DOCKERHUB_USERNAME }}"


### PR DESCRIPTION
The DockerHub publish job in the testing workflow was failing on pushes to `main` because of a hardcoded `organisation: 'oransc'` and missing secrets required for publishing container images. This pull request substitutes the hardcoded organisation with `${{ vars.DOCKERHUB_USERNAME }}`. `vars.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_PASSWORD` have also now been created/set in the repository.