### PR TITLE
Fix: Stop duplicating chart name in helm push URL

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -194,9 +194,12 @@ runs:
           fi
 
           set +e  # Don't exit on individual helm push failure, process all
-          # Push the chart to the registry using the org as repo namespace
+          # Push the chart to the registry; helm push appends the chart
+          # name (from Chart.yaml) to the target URL automatically, so
+          # the URL must stop at the organisation/namespace to avoid
+          # duplication (e.g. org/chart/chart)
           if helm push "$file" \
-            "oci://${{ inputs.registry }}/${{ inputs.organisation }}/${chart_repo}"
+            "oci://${{ inputs.registry }}/${{ inputs.organisation }}"
           then
             echo "Successfully published: $file ✅"
             filename=$(basename "$file")


### PR DESCRIPTION
## Problem

The DockerHub publish job failed on `main` with:

```
Error: failed to perform "Exists" on destination: HEAD
"https://registry-1.docker.io/v2/mattwatkinslf/test-chart/test-chart/manifests/sha256:..."
response status code 401: Unauthorized
```

Note the duplicated `test-chart/test-chart` path segment.

## Root cause

`helm push` automatically appends the chart name (read from
`Chart.yaml`) to the target OCI URL. The action was building the
target URL as:

```
oci://<registry>/<organisation>/<chart_repo>
```

...which, after helm's own chart-name append, resolves to:

```
<registry>/<organisation>/<chart_repo>/<chart_repo>
```

On Docker Hub, pushes to a nonexistent repository path are rejected
with 401 Unauthorized (rather than 404), which matches the observed
failure.

## Fix

Stop passing `${chart_repo}` in the push URL. The action now pushes
to `oci://<registry>/<organisation>` and lets `helm push` place the
chart at `<organisation>/<chart_repo>` as intended.

The `chart_repo` extraction is retained as a validation step to skip
any tgz that lacks a parseable `Chart.yaml` before attempting the
push.