### PR TITLE
CI(testing): Accept DOCKERHUB_USER or DOCKERHUB_USERNAME

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -128,7 +128,11 @@ jobs:
       - uses: ./
         with:
           registry: 'docker.io'
-          username: "${{ vars.DOCKERHUB_USERNAME }}"
+          # Prefer canonical DOCKERHUB_USER; fall back to
+          # DOCKERHUB_USERNAME for backwards compatibility
+          # yamllint disable-line rule:line-length
+          username: "${{ vars.DOCKERHUB_USER || vars.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
           charts_path: "${{ needs.build.outputs.charts_build_dir }}"
-          organisation: "${{ vars.DOCKERHUB_USERNAME }}"
+          # yamllint disable-line rule:line-length
+          organisation: "${{ vars.DOCKERHUB_USER || vars.DOCKERHUB_USERNAME }}"


### PR DESCRIPTION
## Summary

The testing workflow's DockerHub-publish job uses `vars.DOCKERHUB_USERNAME`, but the canonical variable name used across the `lfreleng-actions` repositories and the `releng-reusable-workflows` reusable workflows (e.g. `compose-docker-verify.yaml`, `compose-docker-release-verify.yaml`) is `DOCKERHUB_USER`. Downstream orgs (ONAP, O-RAN-SC, OpenDaylight) only define `DOCKERHUB_USER` at the org level.

## Change

Resolve the `username` and `organisation` inputs with a short-circuit fallback:

```yaml
username:     ${{ vars.DOCKERHUB_USER || vars.DOCKERHUB_USERNAME }}
organisation: ${{ vars.DOCKERHUB_USER || vars.DOCKERHUB_USERNAME }}
```

## Backwards compatibility

- If an org defines `DOCKERHUB_USER` (the canonical name) it is used.
- If only `DOCKERHUB_USERNAME` is defined (the current behaviour), the workflow keeps working unchanged.
- If neither is defined, the behaviour is the same as before (empty value).

No action inputs or org-level configuration need to change as part of this PR; it is a pure compatibility widening.

## Rationale

Consolidating on `DOCKERHUB_USER` aligns this repo with the rest of the ecosystem, which reduces confusion for downstream orgs that have to set up variables once for all actions/workflows they consume.
